### PR TITLE
Conditional statements should not include jinja2 templating delimiters

### DIFF
--- a/tasks/config.yaml
+++ b/tasks/config.yaml
@@ -23,19 +23,19 @@
   shell: "checkmodule -M -m -o {{ item.item|basename|replace('.te', '.mod') }} {{ item.item|basename }}"
   args:
     chdir: "{{ semodule_file_type_enforcement_dest }}"
-  when: "{{ item.changed }}"
+  when: item.changed
   with_items: "{{ results.results }}"
 
 - name: semodule_package
   shell: "semodule_package -o {{ item.item|basename|replace('.te', '.pp') }} -m {{ item.item|basename|replace('.te', '.mod') }}"
   args:
     chdir: "{{ semodule_file_type_enforcement_dest }}"
-  when: "{{ item.changed }}"
+  when: item.changed
   with_items: "{{ results.results }}"
 
 - name: semodule
   shell: "semodule -i {{ item.item|basename|replace('.te', '.pp') }}"
   args:
     chdir: "{{ semodule_file_type_enforcement_dest }}"
-  when: "{{ item.changed }}"
+  when: item.changed
   with_items: "{{ results.results }}"


### PR DESCRIPTION
Remove the following warnings from ansible-playbook:

  TASK [semodule : checkmodule] *************************************************
  Thursday 15 April 2021  20:03:57 +0200 (0:00:00.886)       0:04:07.711 ********
    [WARNING]: conditional statements should not include jinja2 templating
    delimiters such as {{ }} or {% %}. Found: {{ item.changed }}

  Same for "TASK [semodule : semodule_package]" and "TASK [semodule : semodule]".

  I think we need to change the lines
    when: "{{ item.changed }}"
  to
    when: item.changed